### PR TITLE
Feat: Add Z-order controls to dashboard widgets

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -1280,7 +1280,7 @@ class MainWindow(QMainWindow):
             new_widget.run_sequence_requested.connect(self.run_sequence_by_name)
             new_widget.stop_sequence_requested.connect(self.stop_sequence_loop)
         new_widget.request_delete.connect(self.delete_widget)
-        new_widget.widget_changed.connect(lambda: self.set_project_dirty(True))
+        new_widget.state_changed.connect(lambda: self.set_project_dirty(True))
         self.pages[self.current_page_index].append(new_widget)
         if geometry:
             new_widget.move(geometry['x'], geometry['y'])

--- a/app/ui/widgets/base_widget.py
+++ b/app/ui/widgets/base_widget.py
@@ -248,6 +248,17 @@ class BaseWidget(QFrame):
             minimize_action = QAction("Minimize", self)
             minimize_action.triggered.connect(self.toggle_minimize_state)
             context_menu.addAction(minimize_action)
+
+        context_menu.addSeparator()
+
+        front_action = QAction("Bring to Front", self)
+        front_action.triggered.connect(self.bring_to_front)
+        context_menu.addAction(front_action)
+
+        back_action = QAction("Send to Back", self)
+        back_action.triggered.connect(self.send_to_back)
+        context_menu.addAction(back_action)
+
         context_menu.addSeparator()
         copy_action = QAction("Copy", self)
         copy_action.triggered.connect(lambda: self.request_copy.emit(self.config))
@@ -260,6 +271,14 @@ class BaseWidget(QFrame):
         delete_action.triggered.connect(lambda: self.request_delete.emit(self))
         context_menu.addAction(delete_action)
         context_menu.exec(event.globalPos())
+
+    def bring_to_front(self):
+        self.raise_()
+        self.state_changed.emit(self.is_minimized)
+
+    def send_to_back(self):
+        self.lower()
+        self.state_changed.emit(self.is_minimized)
 
     def toggle_minimize_state(self):
         self.is_minimized = not self.is_minimized


### PR DESCRIPTION
This commit adds "Bring to Front" and "Send to Back" options to the context menu of dashboard widgets.

These actions allow the user to control the stacking order of widgets on the dashboard, which is useful for managing overlapping elements.

The changes were made in `app/ui/widgets/base_widget.py`. The `raise_()` and `lower()` methods are used to modify the Z-order, and the `state_changed` signal is emitted to ensure the project is marked as dirty when the order is changed.