### PR TITLE
feat: Allow resizing of minimized widgets and fix delete command

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -1280,7 +1280,7 @@ class MainWindow(QMainWindow):
             new_widget.run_sequence_requested.connect(self.run_sequence_by_name)
             new_widget.stop_sequence_requested.connect(self.stop_sequence_loop)
         new_widget.request_delete.connect(self.delete_widget)
-        new_widget.widget_changed.connect(lambda: self.set_project_dirty(True))
+        new_widget.state_changed.connect(lambda: self.set_project_dirty(True))
         self.pages[self.current_page_index].append(new_widget)
         if geometry:
             new_widget.move(geometry['x'], geometry['y'])


### PR DESCRIPTION
This commit introduces two main changes:
1.  A new feature that allows dashboard widgets to be resized even when they are in their minimized state. This was achieved by removing `setFixedSize` and adjusting the mouse event handlers in `base_widget.py`.
2.  A bug fix for an `AttributeError` that occurred when deleting a `DataConnection` in the sequencer. The `DeleteItemsCommand` was trying to access a non-existent `control_point` attribute. This has been corrected to use the proper control point attributes (`h_control_y1`, etc.) for both serialization and deserialization in the undo stack.