### PR TITLE
Fix: Persist resized dimensions of minimized widgets

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -1292,7 +1292,14 @@ class MainWindow(QMainWindow):
             original_size_data = widget_data.get("original_size")
             if original_size_data:
                 new_widget._original_size = QSize(original_size_data['width'], original_size_data['height'])
+
+            minimized_size_data = widget_data.get("minimized_size")
+            if minimized_size_data:
+                new_widget._minimized_size = QSize(minimized_size_data['width'], minimized_size_data['height'])
+
+            # This will now use the restored _minimized_size if available
             new_widget.toggle_minimize_state()
+
         new_widget.show()
         self.set_project_dirty(True)
         if not self.opcua_logic.is_connected:


### PR DESCRIPTION
Previously, when a minimized widget was resized, its new dimensions were not saved. Upon reloading a project, the widget would revert to its default minimized size instead of the user-defined size.

This was caused by two issues:
1. The `serialize` method in `BaseWidget` did not have a dedicated field to store the resized minimized state.
2. The `toggle_minimize_state` method would hardcode the widget's size to a default value when minimizing, overwriting any size loaded from the project file.

This commit addresses the issue by:
- Introducing a `_minimized_size` attribute to `BaseWidget` to store the custom minimized dimensions.
- Updating `mouseReleaseEvent` to capture the new size in `_minimized_size` when a minimized widget is resized.
- Modifying the `serialize` method to save `minimized_size` and to consistently store the widget's maximized dimensions in the `geometry` field.
- Updating `toggle_minimize_state` to use the stored `_minimized_size` when it's available.
- Adjusting the widget loading logic in `MainWindow` to properly read the `minimized_size` and apply it to the widget before it is displayed.