### PR TITLE
feat: Enhance Python Script node with global variable access

### DIFF
--- a/app/ui/global_variables_widget.py
+++ b/app/ui/global_variables_widget.py
@@ -1,0 +1,165 @@
+"""
+Global Variables Widget for the Node-Based Sequencer.
+
+This module contains the GlobalVariablesWidget class, which provides a UI
+for users to define and manage global variables for their projects. These
+variables can then be accessed and manipulated by nodes within the sequence editor.
+"""
+import logging
+from PyQt6.QtWidgets import (QWidget, QVBoxLayout, QTableWidget, QTableWidgetItem,
+                             QPushButton, QHBoxLayout, QComboBox, QHeaderView)
+from PyQt6.QtCore import Qt, pyqtSignal
+
+class GlobalVariablesWidget(QWidget):
+    """
+    A widget for managing global variables.
+
+    This widget displays global variables in a table and allows users to add,
+    remove, and edit them. It signals changes so that other parts of the
+    application, like node configuration dialogs, can stay in sync.
+    """
+    variables_changed = pyqtSignal()
+
+    def __init__(self, main_window, parent=None):
+        """
+        Initializes the GlobalVariablesWidget.
+
+        Args:
+            main_window (MainWindow): A reference to the main application window,
+                                      which holds the global_variables dictionary.
+            parent (QWidget, optional): The parent widget. Defaults to None.
+        """
+        super().__init__(parent)
+        self.main_window = main_window
+        self.data_types = ["String", "Integer", "Float", "Boolean"]
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(2, 2, 2, 2)
+
+        self.table = QTableWidget()
+        self.table.setColumnCount(3)
+        self.table.setHorizontalHeaderLabels(["Name", "Type", "Value"])
+        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+        self.table.itemChanged.connect(self.on_item_changed)
+        layout.addWidget(self.table)
+
+        button_layout = QHBoxLayout()
+        add_button = QPushButton("Add Variable")
+        add_button.clicked.connect(self.add_variable)
+        remove_button = QPushButton("Remove Variable")
+        remove_button.clicked.connect(self.remove_variable)
+        button_layout.addWidget(add_button)
+        button_layout.addWidget(remove_button)
+        layout.addLayout(button_layout)
+
+    def add_variable(self):
+        """Adds a new, empty row to the variables table."""
+        row_position = self.table.rowCount()
+        self.table.insertRow(row_position)
+
+        name_item = QTableWidgetItem(f"new_variable_{row_position}")
+        self.table.setItem(row_position, 0, name_item)
+
+        type_combo = QComboBox()
+        type_combo.addItems(self.data_types)
+        type_combo.currentIndexChanged.connect(self.on_type_changed)
+        self.table.setCellWidget(row_position, 1, type_combo)
+
+        value_item = QTableWidgetItem("0")
+        self.table.setItem(row_position, 2, value_item)
+
+        self.update_global_variables()
+
+    def remove_variable(self):
+        """Removes the currently selected row from the variables table."""
+        current_row = self.table.currentRow()
+        if current_row >= 0:
+            self.table.removeRow(current_row)
+            self.update_global_variables()
+
+    def on_item_changed(self, item):
+        """
+        Handles changes to items in the table (Name or Value).
+
+        Args:
+            item (QTableWidgetItem): The item that was changed.
+        """
+        self.update_global_variables()
+
+    def on_type_changed(self, index):
+        """
+        Handles changes to the data type QComboBox.
+
+        Args:
+            index (int): The new index of the combo box.
+        """
+        self.update_global_variables()
+
+    def update_global_variables(self):
+        """
+        Reads the entire table and updates the main window's global_variables
+        dictionary. Emits the variables_changed signal.
+        """
+        variables = {}
+        for row in range(self.table.rowCount()):
+            try:
+                name = self.table.item(row, 0).text()
+                type_widget = self.table.cellWidget(row, 1)
+                type_str = type_widget.currentText() if type_widget else "String"
+                value_str = self.table.item(row, 2).text()
+
+                value = self.cast_value(value_str, type_str)
+                variables[name] = {'type': type_str, 'value': value}
+            except Exception as e:
+                logging.error(f"Error processing global variable at row {row}: {e}")
+
+        self.main_window.global_variables = variables
+        self.variables_changed.emit()
+        logging.debug(f"Global variables updated: {self.main_window.global_variables}")
+
+    def cast_value(self, value_str, type_str):
+        """
+        Casts a string value to the specified data type.
+
+        Args:
+            value_str (str): The string representation of the value.
+            type_str (str): The target data type.
+
+        Returns:
+            The value cast to the appropriate type.
+        """
+        try:
+            if type_str == "Integer":
+                return int(value_str)
+            elif type_str == "Float":
+                return float(value_str)
+            elif type_str == "Boolean":
+                return value_str.lower() in ['true', '1', 't', 'yes']
+            else: # String
+                return value_str
+        except (ValueError, TypeError):
+            logging.warning(f"Could not cast '{value_str}' to {type_str}. Returning as string.")
+            return value_str
+
+    def load_variables(self):
+        """
+        Populates the table from the main window's global_variables dictionary.
+        """
+        self.table.blockSignals(True)
+        self.table.setRowCount(0)
+        for name, data in self.main_window.global_variables.items():
+            row_position = self.table.rowCount()
+            self.table.insertRow(row_position)
+
+            name_item = QTableWidgetItem(name)
+            self.table.setItem(row_position, 0, name_item)
+
+            type_combo = QComboBox()
+            type_combo.addItems(self.data_types)
+            type_combo.setCurrentText(data.get('type', 'String'))
+            type_combo.currentIndexChanged.connect(self.on_type_changed)
+            self.table.setCellWidget(row_position, 1, type_combo)
+
+            value_item = QTableWidgetItem(str(data.get('value', '')))
+            self.table.setItem(row_position, 2, value_item)
+        self.table.blockSignals(False)

--- a/app/ui/sequencer_editor.py
+++ b/app/ui/sequencer_editor.py
@@ -32,6 +32,43 @@ from .python_script_dialog import PythonScriptDialog
 from app.core.mysql_manager import MySQLManager
 from PyQt6.QtCore import QSettings
 
+class VariableNodeDialog(QDialog):
+    """A dialog for configuring Set/Get Variable nodes."""
+    def __init__(self, parent=None, current_config=None, available_variables=None):
+        super().__init__(parent)
+        self.setWindowTitle("Configure Variable Node")
+        self.config = current_config or {}
+
+        layout = QVBoxLayout(self)
+        form_layout = QFormLayout()
+
+        self.variable_combo = QComboBox()
+        if available_variables:
+            self.variable_combo.addItems(available_variables)
+
+        form_layout.addRow("Variable Name:", self.variable_combo)
+        layout.addLayout(form_layout)
+
+        button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+
+        if self.config.get('variable_name'):
+            self.variable_combo.setCurrentText(self.config['variable_name'])
+
+    def get_config(self):
+        """Retrieves the updated configuration from the dialog."""
+        selected_variable = self.variable_combo.currentText()
+        if not selected_variable:
+            show_error_message("Configuration Error", "You must select a variable.")
+            return None
+
+        self.config['variable_name'] = selected_variable
+        node_type = self.config.get('node_type', 'Variable')
+        self.config['label'] = f"{node_type}: {selected_variable}"
+        return self.config
+
 class MySQLReadNodeDialog(QDialog):
     """A dialog for configuring the MySQL Read Node."""
     def __init__(self, parent=None, current_config=None):
@@ -1212,15 +1249,8 @@ class SequenceEngine(QObject):
     async def execute_set_variable_node(self, node_data):
         """
         Executes a 'Set Variable' node.
-
         It resolves an input value and stores it in the shared `global_variables`
-        dictionary under a configured name.
-
-        Args:
-            node_data (dict): The data for the 'Set Variable' node.
-
-        Returns:
-            tuple: A tuple containing True and a success boolean.
+        dictionary under a configured name. The variable must already exist.
         """
         try:
             config = node_data['config']
@@ -1228,8 +1258,27 @@ class SequenceEngine(QObject):
             if not variable_name:
                 raise ValueError("Variable name is not configured.")
 
+            if variable_name not in self.global_variables:
+                logging.error(f"Set Variable Node: Global variable '{variable_name}' does not exist and must be declared first.")
+                return None, False
+
             value_to_set = await self.resolve_argument_value(node_data, self.current_sequence_name)
-            self.global_variables[variable_name] = value_to_set
+
+            # Ensure the value is cast to the variable's defined type
+            var_type = self.global_variables[variable_name].get('type', 'String')
+            try:
+                if var_type == "Integer":
+                    value_to_set = int(float(value_to_set)) # float first to handle "1.0"
+                elif var_type == "Float":
+                    value_to_set = float(value_to_set)
+                elif var_type == "Boolean":
+                    value_to_set = str(value_to_set).lower() in ['true', '1', 't', 'yes']
+                # No casting needed for String
+            except (ValueError, TypeError) as e:
+                logging.error(f"Could not cast value '{value_to_set}' to type '{var_type}' for variable '{variable_name}': {e}")
+                return None, False
+
+            self.global_variables[variable_name]['value'] = value_to_set
             logging.info(f"Set global variable '{variable_name}' to: {value_to_set}")
             return True, True
         except Exception as e:
@@ -1239,15 +1288,8 @@ class SequenceEngine(QObject):
     async def execute_get_variable_node(self, node_data):
         """
         Executes a 'Get Variable' node.
-
         It retrieves a value from the shared `global_variables` dictionary
         and places it in the execution context for other nodes to use.
-
-        Args:
-            node_data (dict): The data for the 'Get Variable' node.
-
-        Returns:
-            tuple: A tuple containing the retrieved value and a success boolean.
         """
         try:
             config = node_data['config']
@@ -1255,9 +1297,12 @@ class SequenceEngine(QObject):
             if not variable_name:
                 raise ValueError("Variable name is not configured.")
 
-            value = self.global_variables.get(variable_name)
-            if value is None:
+            variable_data = self.global_variables.get(variable_name)
+            if variable_data is None:
                 logging.warning(f"Global variable '{variable_name}' not found. Returning None.")
+                value = None
+            else:
+                value = variable_data.get('value')
 
             self.execution_context[node_data['uuid']] = value
             logging.info(f"Retrieved global variable '{variable_name}'. Value: {value}")
@@ -1302,16 +1347,9 @@ class SequenceEngine(QObject):
     async def execute_python_script_node(self, node_data):
         """
         Executes a 'Python Script' node.
-
-        The script is executed in a restricted scope with access to an 'INPUT'
-        variable. The script can set an 'output' variable, which is then
-        placed in the execution context.
-
-        Args:
-            node_data (dict): The data for the python script node.
-
-        Returns:
-            tuple: A tuple containing the script's output and a success boolean.
+        The script is executed in a scope containing all global variables,
+        which it can read and modify. It also has access to an 'INPUT'
+        variable from a data connection and can set an 'output' variable.
         """
         try:
             config = node_data['config']
@@ -1319,10 +1357,44 @@ class SequenceEngine(QObject):
             if not script:
                 return None, True
 
+            # Prepare the scope for the script, pre-filling it with global variable values
+            script_globals = {name: data.get('value') for name, data in self.global_variables.items()}
+
+            # Add INPUT and output variables to the scope
             input_value = await self.resolve_argument_value(node_data, self.current_sequence_name)
-            local_scope = {'INPUT': input_value, 'output': None}
-            exec(script, {}, local_scope)
-            output_value = local_scope.get('output')
+            script_globals['INPUT'] = input_value
+            script_globals['output'] = None
+
+            # Execute the script
+            exec(script, {}, script_globals)
+
+            # Update global variables from the script's scope, enforcing types
+            for name, value in script_globals.items():
+                if name in self.global_variables:
+                    # Don't process special variables back into the main dict
+                    if name in ['INPUT', 'output', '__builtins__']:
+                        continue
+
+                    original_value = self.global_variables[name].get('value')
+
+                    # Only update if the value has changed
+                    if original_value != value:
+                        var_type = self.global_variables[name].get('type', 'String')
+                        try:
+                            if var_type == "Integer":
+                                value = int(float(value))
+                            elif var_type == "Float":
+                                value = float(value)
+                            elif var_type == "Boolean":
+                                value = bool(value)
+                        except (ValueError, TypeError):
+                             logging.warning(f"Python script: Could not cast '{value}' back to type '{var_type}' for variable '{name}'. Change will be ignored.")
+                             continue # Skip update if cast fails
+
+                        self.global_variables[name]['value'] = value
+                        logging.info(f"Python script updated global variable '{name}' to: {value}")
+
+            output_value = script_globals.get('output')
             self.execution_context[node_data['uuid']] = output_value
             logging.info(f"Python script node executed. Output: {output_value}")
             return output_value, True
@@ -1860,6 +1932,11 @@ class SequenceNode(QGraphicsObject):
             self.data_in_socket.setPos(self.width / 2, 0)
         elif node_type == NodeType.GET_VARIABLE.value:
             self.data_out_socket = DataSocket(self, is_output=True, label="Value")
+            self.data_out_socket.setPos(self.width / 2, self.height)
+        elif node_type == NodeType.PYTHON_SCRIPT.value:
+            self.data_in_socket = DataSocket(self, is_output=False, label="In")
+            self.data_in_socket.setPos(self.width / 2, 0)
+            self.data_out_socket = DataSocket(self, is_output=True, label="Out")
             self.data_out_socket.setPos(self.width / 2, self.height)
         elif node_type in [NodeType.FOR_LOOP.value, NodeType.WHILE_LOOP.value]:
              self.out_port.hide()
@@ -2819,13 +2896,17 @@ class SequenceScene(QGraphicsScene):
             elif node_type == NodeType.COMPUTE.value:
                 dialog = ComputeNodeDialog(self.views()[0], current_config=item.config)
             elif node_type == NodeType.SET_VARIABLE.value or node_type == NodeType.GET_VARIABLE.value:
-                var_name, ok = QInputDialog.getText(self.views()[0], f"Configure {node_type}", "Variable Name:", text=item.config.get('variable_name', ''))
-                if ok and var_name:
-                    item.config['variable_name'] = var_name
-                    item.config['label'] = f"{node_type}: {var_name}"
-                    item.update_title()
-                    self.scene_changed.emit()
-                return
+                if hasattr(self, 'main_window'):
+                    available_vars = list(self.main_window.global_variables.keys())
+                    dialog = VariableNodeDialog(self.views()[0], current_config=item.config, available_variables=available_vars)
+                else: # Fallback just in case
+                    var_name, ok = QInputDialog.getText(self.views()[0], f"Configure {node_type}", "Variable Name:", text=item.config.get('variable_name', ''))
+                    if ok and var_name:
+                        item.config['variable_name'] = var_name
+                        item.config['label'] = f"{node_type}: {var_name}"
+                        item.update_title()
+                        self.scene_changed.emit()
+                    return
             elif node_type == NodeType.RUN_SEQUENCE.value:
                 editor = self.views()[0]
                 dialog = RunSequenceDialog(editor, item.config, editor.available_sequences, editor.current_sequence)
@@ -2929,9 +3010,11 @@ class SequenceEditor(QGraphicsView):
     scene_changed = pyqtSignal()
 
     """The main view widget for the sequencer scene."""
-    def __init__(self, parent=None):
+    def __init__(self, *, main_window, parent=None):
         super().__init__(parent)
+        self.main_window = main_window
         self.scene = SequenceScene(self)
+        self.scene.main_window = main_window
         self.setScene(self.scene)
         self.scene.scene_changed.connect(self.scene_changed)
         self.scene.add_new_node_requested.connect(self.on_add_new_node)


### PR DESCRIPTION
This commit enhances the Python Script node in the sequencer to allow access to and modification of global variables.

- The Python Script node now receives all global variables in its execution scope, allowing for direct reading and writing of their values.
- Changes made to global variables within the script are persisted back to the main application state, with data types enforced.
- A data input socket has been added to the Python Script node to allow it to receive an `INPUT` value from other nodes.
- The `Set/Get Variable` nodes have been fixed to correctly handle the new global variable data structure.