### PR TITLE
feat: Implement dynamic and retentive global variables

### DIFF
--- a/app/ui/global_variables_widget.py
+++ b/app/ui/global_variables_widget.py
@@ -1,0 +1,198 @@
+"""
+Global Variables Widget for the Node-Based Sequencer.
+
+This module contains the GlobalVariablesWidget class, which provides a UI
+for users to define and manage global variables for their projects. These
+variables can then be accessed and manipulated by nodes within the sequence editor.
+"""
+import logging
+from PyQt6.QtWidgets import (QWidget, QVBoxLayout, QTableWidget, QTableWidgetItem,
+                             QPushButton, QHBoxLayout, QComboBox, QHeaderView, QCheckBox)
+from PyQt6.QtCore import Qt, pyqtSignal
+
+class GlobalVariablesWidget(QWidget):
+    """
+    A widget for managing global variables.
+    This widget displays global variables in a table and allows users to add,
+    remove, and edit their definitions (name, type, initial value, retentive status).
+    It also displays the live 'current value' during sequence execution.
+    """
+    variables_changed = pyqtSignal()
+
+    def __init__(self, main_window, parent=None):
+        super().__init__(parent)
+        self.main_window = main_window
+        self.data_types = ["String", "Integer", "Float", "Boolean"]
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(2, 2, 2, 2)
+
+        self.table = QTableWidget()
+        self.table.setColumnCount(5)
+        self.table.setHorizontalHeaderLabels(["Name", "Type", "Initial Value", "Retentive", "Current Value"])
+        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+        self.table.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeMode.Interactive)
+        self.table.horizontalHeader().setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)
+        self.table.itemChanged.connect(self.on_item_changed)
+        layout.addWidget(self.table)
+
+        button_layout = QHBoxLayout()
+        add_button = QPushButton("Add Variable")
+        add_button.clicked.connect(self.add_variable)
+        remove_button = QPushButton("Remove Variable")
+        remove_button.clicked.connect(self.remove_variable)
+        button_layout.addWidget(add_button)
+        button_layout.addWidget(remove_button)
+        layout.addLayout(button_layout)
+
+    def add_variable(self):
+        """Adds a new, empty row to the variables table for definition."""
+        row_position = self.table.rowCount()
+        self.table.insertRow(row_position)
+
+        name_item = QTableWidgetItem(f"new_variable_{row_position}")
+        self.table.setItem(row_position, 0, name_item)
+
+        type_combo = QComboBox()
+        type_combo.addItems(self.data_types)
+        type_combo.currentIndexChanged.connect(self.on_cell_widget_changed)
+        self.table.setCellWidget(row_position, 1, type_combo)
+
+        initial_value_item = QTableWidgetItem("0")
+        self.table.setItem(row_position, 2, initial_value_item)
+
+        retentive_checkbox = QCheckBox()
+        retentive_checkbox.stateChanged.connect(self.on_cell_widget_changed)
+        cell_widget = QWidget()
+        layout = QHBoxLayout(cell_widget)
+        layout.addWidget(retentive_checkbox)
+        layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.setContentsMargins(0,0,0,0)
+        self.table.setCellWidget(row_position, 3, cell_widget)
+
+        current_value_item = QTableWidgetItem("0")
+        current_value_item.setFlags(current_value_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
+        self.table.setItem(row_position, 4, current_value_item)
+
+        self.update_global_variables()
+
+    def remove_variable(self):
+        """Removes the currently selected row from the variables table."""
+        current_row = self.table.currentRow()
+        if current_row >= 0:
+            self.table.removeRow(current_row)
+            self.update_global_variables()
+
+    def on_item_changed(self, item):
+        """Handles changes to editable items in the table (Name or Initial Value)."""
+        self.update_global_variables()
+
+    def on_cell_widget_changed(self, index):
+        """Handles changes to cell widgets (Type ComboBox or Retentive CheckBox)."""
+        self.update_global_variables()
+
+    def update_global_variables(self):
+        """
+        Reads the entire table and updates the main window's global_variables
+        dictionary. Emits the variables_changed signal. This method defines the
+        structure of the variables but preserves the 'current_value' from the
+        existing state if available.
+        """
+        variables = {}
+        for row in range(self.table.rowCount()):
+            try:
+                name = self.table.item(row, 0).text()
+                if not name: continue
+
+                type_widget = self.table.cellWidget(row, 1)
+                type_str = type_widget.currentText() if type_widget else "String"
+
+                initial_value_str = self.table.item(row, 2).text()
+                initial_value = self.cast_value(initial_value_str, type_str)
+
+                retentive_widget = self.table.cellWidget(row, 3)
+                retentive = retentive_widget.findChild(QCheckBox).isChecked() if retentive_widget else False
+
+                # Preserve the existing current_value if the variable already exists.
+                # Otherwise, the current_value starts as the initial_value.
+                current_value = initial_value
+                if name in self.main_window.global_variables:
+                    current_value = self.main_window.global_variables[name].get('current_value', initial_value)
+
+                variables[name] = {
+                    'type': type_str,
+                    'initial_value': initial_value,
+                    'retentive': retentive,
+                    'current_value': current_value
+                }
+
+                # Update the read-only current value display in the table
+                current_val_item = self.table.item(row, 4)
+                if current_val_item.text() != str(current_value):
+                    current_val_item.setText(str(current_value))
+
+            except Exception as e:
+                logging.error(f"Error processing global variable at row {row}: {e}")
+
+        self.main_window.global_variables = variables
+        self.variables_changed.emit()
+        logging.debug(f"Global variables updated: {self.main_window.global_variables}")
+
+    def cast_value(self, value_str, type_str):
+        """Casts a string value to the specified data type."""
+        try:
+            if type_str == "Integer":
+                return int(float(value_str)) # Handle "1.0"
+            elif type_str == "Float":
+                return float(value_str)
+            elif type_str == "Boolean":
+                return value_str.lower() in ['true', '1', 't', 'yes']
+            else: # String
+                return value_str
+        except (ValueError, TypeError):
+            logging.warning(f"Could not cast '{value_str}' to {type_str}. Returning as string.")
+            return value_str
+
+    def load_variables(self):
+        """Populates the table from the main window's global_variables dictionary."""
+        self.table.blockSignals(True)
+        self.table.setRowCount(0)
+        for name, data in self.main_window.global_variables.items():
+            row_position = self.table.rowCount()
+            self.table.insertRow(row_position)
+
+            self.table.setItem(row_position, 0, QTableWidgetItem(name))
+
+            type_combo = QComboBox()
+            type_combo.addItems(self.data_types)
+            type_combo.setCurrentText(data.get('type', 'String'))
+            type_combo.currentIndexChanged.connect(self.on_cell_widget_changed)
+            self.table.setCellWidget(row_position, 1, type_combo)
+
+            self.table.setItem(row_position, 2, QTableWidgetItem(str(data.get('initial_value', ''))))
+
+            retentive_checkbox = QCheckBox()
+            retentive_checkbox.setChecked(data.get('retentive', False))
+            retentive_checkbox.stateChanged.connect(self.on_cell_widget_changed)
+            cell_widget = QWidget()
+            layout = QHBoxLayout(cell_widget)
+            layout.addWidget(retentive_checkbox)
+            layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            layout.setContentsMargins(0,0,0,0)
+            self.table.setCellWidget(row_position, 3, cell_widget)
+
+            current_value_item = QTableWidgetItem(str(data.get('current_value', '')))
+            current_value_item.setFlags(current_value_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
+            self.table.setItem(row_position, 4, current_value_item)
+
+        self.table.blockSignals(False)
+
+    def update_variable_display(self, name, value):
+        """Updates a single variable's 'Current Value' cell in the table."""
+        for row in range(self.table.rowCount()):
+            if self.table.item(row, 0).text() == name:
+                # Block signals to prevent this UI update from re-triggering a full update
+                self.table.blockSignals(True)
+                self.table.item(row, 4).setText(str(value))
+                self.table.blockSignals(False)
+                break

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -38,6 +38,7 @@ from app.ui.widgets.switch_widget import SwitchWidget
 from app.ui.widgets.input_widget import InputWidget
 from app.ui.widgets.button_widget import ButtonWidget
 from app.ui.widgets.plotter_widget import PlotterWidget
+from app.ui.global_variables_widget import GlobalVariablesWidget
 
 class ServerSettingsDialog(QDialog):
     """Dialog for configuring server connection settings."""
@@ -495,6 +496,7 @@ class MainWindow(QMainWindow):
     def _create_docks(self):
         self._create_server_tree_dock()
         self._create_sequence_tree_dock()
+        self._create_global_variables_dock()
         self._create_log_dock()
 
     def show_start_page(self):
@@ -505,6 +507,8 @@ class MainWindow(QMainWindow):
         self.title_bar.menu_bar.hide()
         self.server_tree_dock.hide()
         self.sequence_tree_dock.hide()
+        if hasattr(self, 'global_variables_dock'):
+            self.global_variables_dock.hide()
         self.log_dock.hide()
         self.start_page.populate_recent_projects(self.get_recent_projects())
         
@@ -523,6 +527,8 @@ class MainWindow(QMainWindow):
         self.title_bar.menu_bar.show()
         self.server_tree_dock.show()
         self.sequence_tree_dock.show()
+        if hasattr(self, 'global_variables_dock'):
+            self.global_variables_dock.show()
         self.log_dock.show()
         
         screen_geometry = QApplication.primaryScreen().availableGeometry()
@@ -551,6 +557,8 @@ class MainWindow(QMainWindow):
         
         # --- FEATURE: GLOBAL VARIABLES ---
         self.global_variables.clear()
+        if hasattr(self, 'global_variables_widget'):
+            self.global_variables_widget.load_variables()
         
         self.clear_all_pages()
         self.close_all_sequence_tabs()
@@ -617,6 +625,12 @@ class MainWindow(QMainWindow):
                 if server_url and not self.opcua_logic.is_connected:
                     logging.info(f"Project specifies server '{server_url}'. Connecting...")
                     self.toggle_connection()
+
+                # --- FEATURE: GLOBAL VARIABLES ---
+                self.global_variables = project_data.get('global_variables', {})
+                if hasattr(self, 'global_variables_widget'):
+                    self.global_variables_widget.load_variables()
+
             except Exception as e:
                 logging.error(f"Failed to load project file: {e}")
                 show_error_message("File Load Error", "The selected project file could not be loaded.", str(e))
@@ -650,11 +664,12 @@ class MainWindow(QMainWindow):
         
         open_tabs = list(self.open_sequence_editors.keys())
 
-        full_project_data = { 
-            'server_url': server_url, 
-            'dashboard': dashboard_data, 
+        full_project_data = {
+            'server_url': server_url,
+            'dashboard': dashboard_data,
             'sequences': self.sequences,
-            'open_tabs': open_tabs
+            'open_tabs': open_tabs,
+            'global_variables': self.global_variables
         }
         try:
             with open(file_path, 'w') as f:
@@ -913,9 +928,11 @@ class MainWindow(QMainWindow):
         
         self.server_tree_dock = QDockWidget("Server Browser", self)
         self.sequence_tree_dock = QDockWidget("Sequence Library", self)
+        self.global_variables_dock = QDockWidget("Global Variables", self)
         self.log_dock = QDockWidget("Log", self)
         view_menu.addAction(self.server_tree_dock.toggleViewAction())
         view_menu.addAction(self.sequence_tree_dock.toggleViewAction())
+        view_menu.addAction(self.global_variables_dock.toggleViewAction())
         view_menu.addAction(self.log_dock.toggleViewAction())
         
         view_menu.addSeparator()
@@ -1124,6 +1141,25 @@ class MainWindow(QMainWindow):
         self.sequence_tree.create_sequence_widget_requested.connect(self.on_create_sequence_widget_from_tree)
         self.sequence_tree_dock.setWidget(self.sequence_tree)
         self.addDockWidget(Qt.DockWidgetArea.LeftDockWidgetArea, self.sequence_tree_dock)
+
+    def _create_global_variables_dock(self):
+        self.global_variables_dock.setAllowedAreas(Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea)
+        self.global_variables_widget = GlobalVariablesWidget(self)
+        # Connect the signal from the widget to a handler in the main window
+        self.global_variables_widget.variables_changed.connect(self.on_global_variables_changed)
+        self.global_variables_dock.setWidget(self.global_variables_widget)
+        self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self.global_variables_dock)
+
+    def on_global_variables_changed(self):
+        """
+        Handles the signal emitted when global variables are changed.
+        This can be used to update any other UI elements that depend on them.
+        """
+        # For now, we can just log that the change was received.
+        # In the future, this could update combo boxes in node configs, etc.
+        logging.info("Global variables have been updated.")
+        self.set_project_dirty(True)
+
 
     def _create_page_controls(self):
         nav_layout = QHBoxLayout()
@@ -1508,6 +1544,7 @@ class MainWindow(QMainWindow):
         engine.node_state_changed.connect(self.on_node_state_changed)
         engine.connection_state_changed.connect(self.on_connection_state_changed)
         engine.execution_paused.connect(self.on_sequence_paused)
+        engine.global_variable_changed.connect(self.on_global_variable_updated)
 
         self.running_sequences[name] = engine
         
@@ -1633,6 +1670,14 @@ class MainWindow(QMainWindow):
         if editor:
             editor.update_connection_state(start_uuid, end_uuid, state)
 
+    def on_global_variable_updated(self, name, value):
+        """
+        Slot to handle updates to a global variable's value from the engine.
+        Updates the 'Current Value' in the GlobalVariablesWidget.
+        """
+        if hasattr(self, 'global_variables_widget'):
+            self.global_variables_widget.update_variable_display(name, value)
+
     def open_server_settings_dialog(self):
         dialog = ServerSettingsDialog(self)
         dialog.exec()
@@ -1677,7 +1722,7 @@ class MainWindow(QMainWindow):
         if name not in self.sequences:
             logging.error(f"Attempted to open non-existent sequence '{name}' in a tab.")
             return
-        editor = SequenceEditor(self)
+        editor = SequenceEditor(main_window=self, parent=self)
         editor.load_data(self.sequences[name])
         index = self.sequence_tab_widget.addTab(editor, name)
         self.sequence_tab_widget.setCurrentIndex(index)


### PR DESCRIPTION
This commit enhances the global variables feature to support dynamic updates and retentive state.

- The global variable data structure has been updated to include 'initial_value', 'current_value', and a 'retentive' flag.
- The GlobalVariablesWidget now displays the live 'current_value' of variables during sequence execution.
- A 'Retentive' checkbox allows users to specify whether a variable's value should persist between runs.
- Non-retentive variables are reset to their 'initial_value' at the start of each sequence execution.
- The SequenceEngine now emits a signal when a global variable's value changes, allowing the UI to update in real-time.
- The Set/Get Variable and Python Script nodes have been updated to use the new data structure and interact with the 'current_value'.