### PR TITLE
This change sets the default layout to have the global variables dock…

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -414,6 +414,8 @@ class MainWindow(QMainWindow):
         # Set the initial status on the title bar when the window is created.
         self.title_bar.set_connection_status(False)
 
+        self.load_settings()
+
     def _get_resize_edge(self, pos: QPoint):
         """Checks if a given position is within the resize border."""
         top = pos.y() < self.border_thickness
@@ -498,6 +500,7 @@ class MainWindow(QMainWindow):
         self._create_sequence_tree_dock()
         self._create_global_variables_dock()
         self._create_log_dock()
+        self.splitDockWidget(self.log_dock, self.global_variables_dock, Qt.Orientation.Horizontal)
 
     def show_start_page(self):
         self.project_is_active = False
@@ -704,6 +707,8 @@ class MainWindow(QMainWindow):
                 event.ignore()
                 return
 
+        self.save_settings()
+
         logging.info("Close event accepted. Shutting down application...")
         self.reconnect_timer.stop()
         for page in self.pages:
@@ -711,6 +716,20 @@ class MainWindow(QMainWindow):
                 widget.stop_subscription()
         self.async_runner.submit(self.shutdown())
         event.accept()
+
+    def save_settings(self):
+        """Saves window geometry and state."""
+        settings = QSettings("MyCompany", "OPCUA-Client")
+        settings.setValue("geometry", self.saveGeometry())
+        settings.setValue("windowState", self.saveState())
+
+    def load_settings(self):
+        """Loads window geometry and state."""
+        settings = QSettings("MyCompany", "OPCUA-Client")
+        if settings.contains("geometry"):
+            self.restoreGeometry(settings.value("geometry"))
+        if settings.contains("windowState"):
+            self.restoreState(settings.value("windowState"))
     
     def _create_dashboard_tab(self):
         self.dashboard_container = QWidget()
@@ -1128,7 +1147,7 @@ class MainWindow(QMainWindow):
         self.show_start_page()
 
     def _create_server_tree_dock(self):
-        self.server_tree_dock.setAllowedAreas(Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea)
+        self.server_tree_dock.setAllowedAreas(Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea | Qt.DockWidgetArea.BottomDockWidgetArea)
         self.server_tree = ServerTreeView(self.opcua_logic, self.async_runner)
         self.server_tree.create_widget_requested.connect(self.on_create_widget_from_tree)
         self.server_tree.add_to_sequencer_requested.connect(self.add_node_to_current_sequencer)
@@ -1136,14 +1155,14 @@ class MainWindow(QMainWindow):
         self.addDockWidget(Qt.DockWidgetArea.LeftDockWidgetArea, self.server_tree_dock)
 
     def _create_sequence_tree_dock(self):
-        self.sequence_tree_dock.setAllowedAreas(Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea)
+        self.sequence_tree_dock.setAllowedAreas(Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea | Qt.DockWidgetArea.BottomDockWidgetArea)
         self.sequence_tree = SequenceTreeView()
         self.sequence_tree.create_sequence_widget_requested.connect(self.on_create_sequence_widget_from_tree)
         self.sequence_tree_dock.setWidget(self.sequence_tree)
         self.addDockWidget(Qt.DockWidgetArea.LeftDockWidgetArea, self.sequence_tree_dock)
 
     def _create_global_variables_dock(self):
-        self.global_variables_dock.setAllowedAreas(Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea)
+        self.global_variables_dock.setAllowedAreas(Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea | Qt.DockWidgetArea.BottomDockWidgetArea)
         self.global_variables_widget = GlobalVariablesWidget(self)
         # Connect the signal from the widget to a handler in the main window
         self.global_variables_widget.variables_changed.connect(self.on_global_variables_changed)


### PR DESCRIPTION
… positioned to the right of the logs dock at the bottom of the screen.

This is achieved by using `splitDockWidget` after the docks have been created.