### PR TITLE
Fix Python node global variable handling and add verify button

### DIFF
--- a/app/ui/python_script_dialog.py
+++ b/app/ui/python_script_dialog.py
@@ -5,9 +5,10 @@ This module contains the PythonScriptDialog, which embeds a QPlainTextEdit
 with a custom QSyntaxHighlighter for editing Python scripts within the application.
 """
 import sys
-from PyQt6.QtWidgets import (QDialog, QVBoxLayout, QPlainTextEdit, QDialogButtonBox)
+from PyQt6.QtWidgets import (QDialog, QVBoxLayout, QPlainTextEdit, QDialogButtonBox, QPushButton)
 from PyQt6.QtCore import QRegularExpression
 from PyQt6.QtGui import QSyntaxHighlighter, QTextCharFormat, QColor, QFont
+from .error_dialog import show_error_message, show_info_message
 
 from pygments import highlight
 from pygments.lexers.python import PythonLexer
@@ -131,9 +132,26 @@ class PythonScriptDialog(QDialog):
         layout.addWidget(self.editor)
 
         button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+
+        # --- FEATURE: VERIFY SCRIPT ---
+        self.verify_button = QPushButton("Verify")
+        self.verify_button.clicked.connect(self.verify_script)
+        button_box.addButton(self.verify_button, QDialogButtonBox.ButtonRole.ActionRole)
+
         button_box.accepted.connect(self.accept)
         button_box.rejected.connect(self.reject)
         layout.addWidget(button_box)
+
+    def verify_script(self):
+        """
+        Verifies the syntax of the Python script in the editor.
+        """
+        script = self.get_script()
+        try:
+            compile(script, '<string>', 'exec')
+            show_info_message("Syntax OK", "The script syntax is valid.")
+        except SyntaxError as e:
+            show_error_message("Syntax Error", f"The script has a syntax error:\n\n{e}")
 
     def get_script(self):
         """

--- a/app/ui/sequencer_editor.py
+++ b/app/ui/sequencer_editor.py
@@ -1361,9 +1361,28 @@ class SequenceEngine(QObject):
                 return None, True
 
             input_value = await self.resolve_argument_value(node_data, self.current_sequence_name)
-            local_scope = {'INPUT': input_value, 'output': None}
-            exec(script, {}, local_scope)
-            output_value = local_scope.get('output')
+
+            # The script operates on a copy of the global variables, with INPUT and output added.
+            script_globals = self.global_variables.copy()
+
+            # Unwrap any dictionary-like variables to their raw values for the script
+            for key, value in script_globals.items():
+                if isinstance(value, dict) and 'value' in value:
+                    script_globals[key] = value['value']
+
+            script_globals['INPUT'] = input_value
+            script_globals['output'] = None
+
+            exec(script, script_globals)
+
+            # Changes to global variables made by the script are reflected back.
+            for key, value in script_globals.items():
+                if key not in ['__builtins__', 'INPUT']:
+                    if key not in self.global_variables or self.global_variables[key] != value:
+                        self.global_variables[key] = value
+                        self.global_variable_changed.emit(key, value)
+
+            output_value = script_globals.get('output')
             self.execution_context[node_data['uuid']] = output_value
             logging.info(f"Python script node executed. Output: {output_value}")
             return output_value, True


### PR DESCRIPTION
- Modified `execute_python_script_node` to correctly handle global variables, including "unwrapping" dictionary-like variables to their raw values before script execution. This resolves a `TypeError` when performing operations on these variables.

- Added a "Verify" button to the `PythonScriptDialog` to allow users to check their code for syntax errors before execution.